### PR TITLE
Pass -no_fixup_chains to the linker

### DIFF
--- a/zorg/jenkins/jobs/jobs/llvm-coverage
+++ b/zorg/jenkins/jobs/jobs/llvm-coverage
@@ -131,6 +131,7 @@ pipeline {
                       --cmake-flag="-DLLVM_PROFILE_MERGE_POOL_SIZE=1" \
                       --cmake-flag="-DLLVM_ENABLE_MODULES=Off" \
                       --cmake-flag="-DLLVM_TARGETS_TO_BUILD=X86;ARM;AArch64;AMDGPU;WebAssembly" \
+                      --cmake-flag="-DCMAKE_EXE_LINKER_FLAGS=-no_fixup_chains" \
                       --cmake-type=Release \
                       --noupload
                     '''


### PR DESCRIPTION
This is needed to work around a limitation of the linker, which was causing it to crash on coverage-enabled bots.

rdar://146130000